### PR TITLE
merge in changes from uProxy's fork

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,5 +21,17 @@
         </config-file>
 
         <source-file src="src/android/WebIntent.java" target-dir="src/com/borismus/webintent" />
+
+        <config-file target="AndroidManifest.xml" parent="/manifest/application">
+            <receiver
+                android:name="com.borismus.webintent.WebIntent$ReferralReceiver"
+                android:enabled="true"
+                android:exported="true"
+                android:label="@string/app_name">
+                <intent-filter>
+                    <action android:name="com.android.vending.INSTALL_REFERRER" />
+                </intent-filter>
+            </receiver>
+        </config-file>
     </platform>
 </plugin>

--- a/src/android/WebIntent.java
+++ b/src/android/WebIntent.java
@@ -8,128 +8,123 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.text.Html;
+import android.util.Log;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaResourceApi;
 import org.apache.cordova.PluginResult;
 
 /**
  * WebIntent is a PhoneGap plugin that bridges Android intents and web
  * applications:
- * 
- * 1. web apps can spawn intents that call native Android applications. 2.
- * (after setting up correct intent filters for PhoneGap applications), Android
- * intents can be handled by PhoneGap web applications.
- * 
- * @author boris@borismus.com
- * 
+ *
+ * 1. Web apps can spawn intents that call native Android applications.
+ * 2. After setting up correct intent filters for Cordova applications,
+ *    Android intents can be handled by Cordova web applications.
+ *
+ * @author Boris Smus (boris@borismus.com)
+ * @author Chris E. Kelley (chris@vetula.com)
+ *
  */
 public class WebIntent extends CordovaPlugin {
+    private static final String LOG_TAG = "WebIntent";
+    private static String installReferrer = null;
+    private CallbackContext onNewIntentCallbackContext = null;
 
-    //private String onNewIntentCallback = null;
-    private CallbackContext callbackContext = null;
-
-    //public boolean execute(String action, JSONArray args, String callbackId) {
+    /**
+     *
+     * @return true iff if the action was executed successfully, else false.
+     */
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) {
         try {
-            this.callbackContext = callbackContext;
-
             if (action.equals("startActivity")) {
                 if (args.length() != 1) {
-                    //return new PluginResult(PluginResult.Status.INVALID_ACTION);
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                     return false;
                 }
 
                 // Parse the arguments
-				JSONObject obj = args.getJSONObject(0);
-				if (obj.has("package")) {
-					String pkg = obj.getString("package");
-					Intent LaunchIntent = cordova.getActivity().getPackageManager().getLaunchIntentForPackage(pkg);
-					((CordovaActivity)this.cordova.getActivity()).startActivity(LaunchIntent);
-				} else {
-					String type = obj.has("type") ? obj.getString("type") : null;
-					Uri uri = obj.has("url") ? Uri.parse(obj.getString("url")) : null;
-					JSONObject extras = obj.has("extras") ? obj.getJSONObject("extras") : null;
-					Map<String, String> extrasMap = new HashMap<String, String>();
+                final CordovaResourceApi resourceApi = webView.getResourceApi();
+                JSONObject obj = args.getJSONObject(0);
+                String type = obj.has("type") ? obj.getString("type") : null;
+                Uri uri = obj.has("url") ? resourceApi.remapUri(Uri.parse(obj.getString("url"))) : null;
+                JSONObject extras = obj.has("extras") ? obj.getJSONObject("extras") : null;
+                Map<String, String> extrasMap = new HashMap<String, String>();
 
-					// Populate the extras if any exist
-					if (extras != null) {
-						JSONArray extraNames = extras.names();
-						for (int i = 0; i < extraNames.length(); i++) {
-							String key = extraNames.getString(i);
-							String value = extras.getString(key);
-							extrasMap.put(key, value);
-						}
-					}
-					startActivity(obj.getString("action"), uri, type, extrasMap);
-				}
-                //return new PluginResult(PluginResult.Status.OK);
+                // Populate the extras if any exist
+                if (extras != null) {
+                    JSONArray extraNames = extras.names();
+                    for (int i = 0; i < extraNames.length(); i++) {
+                        String key = extraNames.getString(i);
+                        String value = extras.getString(key);
+                        extrasMap.put(key, value);
+                    }
+                }
+
+                startActivity(obj.getString("action"), uri, type, extrasMap);
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
                 return true;
 
             } else if (action.equals("hasExtra")) {
                 if (args.length() != 1) {
-                    //return new PluginResult(PluginResult.Status.INVALID_ACTION);
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                     return false;
                 }
                 Intent i = ((CordovaActivity)this.cordova.getActivity()).getIntent();
                 String extraName = args.getString(0);
-                //return new PluginResult(PluginResult.Status.OK, i.hasExtra(extraName));
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, i.hasExtra(extraName)));
                 return true;
 
             } else if (action.equals("getExtra")) {
                 if (args.length() != 1) {
-                    //return new PluginResult(PluginResult.Status.INVALID_ACTION);
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                     return false;
                 }
                 Intent i = ((CordovaActivity)this.cordova.getActivity()).getIntent();
                 String extraName = args.getString(0);
                 if (i.hasExtra(extraName)) {
-                    //return new PluginResult(PluginResult.Status.OK, i.getStringExtra(extraName));
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, i.getStringExtra(extraName)));
                     return true;
                 } else {
-                    //return new PluginResult(PluginResult.Status.ERROR);
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR));
                     return false;
                 }
             } else if (action.equals("getUri")) {
                 if (args.length() != 0) {
-                    //return new PluginResult(PluginResult.Status.INVALID_ACTION);
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                     return false;
                 }
 
                 Intent i = ((CordovaActivity)this.cordova.getActivity()).getIntent();
                 String uri = i.getDataString();
-                //return new PluginResult(PluginResult.Status.OK, uri);
+                if (uri == null && installReferrer != null) {
+                    uri = installReferrer;  // App just installed, received play store referrer intent.
+                    Log.i(LOG_TAG, String.format("URI is an install referrer: %s", installReferrer));
+                }
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, uri));
                 return true;
             } else if (action.equals("onNewIntent")) {
+                // Save reference to the callback; will be called on "new intent" events.
+                this.onNewIntentCallbackContext = callbackContext;
+
                 if (args.length() != 0) {
-                    //return new PluginResult(PluginResult.Status.INVALID_ACTION);
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                     return false;
                 }
 
-                //this.onNewIntentCallback = callbackId;
                 PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
-                result.setKeepCallback(true);
+                result.setKeepCallback(true); // Reuse the callback on intent events.
                 callbackContext.sendPluginResult(result);
                 return true;
-                //return result;
-            } else if (action.equals("sendBroadcast")) 
-            {
+            } else if (action.equals("sendBroadcast")) {
                 if (args.length() != 1) {
-                    //return new PluginResult(PluginResult.Status.INVALID_ACTION);
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                     return false;
                 }
@@ -151,31 +146,32 @@ public class WebIntent extends CordovaPlugin {
                 }
 
                 sendBroadcast(obj.getString("action"), extrasMap);
-                //return new PluginResult(PluginResult.Status.OK);
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
                 return true;
             }
-            //return new PluginResult(PluginResult.Status.INVALID_ACTION);
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
             return false;
         } catch (JSONException e) {
             e.printStackTrace();
-            //return new PluginResult(PluginResult.Status.JSON_EXCEPTION);
-            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.JSON_EXCEPTION));
+            final String errorMessage = e.getMessage();
+            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.JSON_EXCEPTION, errorMessage));
             return false;
         }
     }
 
     @Override
     public void onNewIntent(Intent intent) {
-        if (this.callbackContext != null) {
-            this.callbackContext.success(intent.getDataString());
+
+        if (this.onNewIntentCallbackContext != null) {
+            PluginResult result = new PluginResult(PluginResult.Status.OK, intent.getDataString());
+            result.setKeepCallback(true);
+            this.onNewIntentCallbackContext.sendPluginResult(result);
         }
     }
 
     void startActivity(String action, Uri uri, String type, Map<String, String> extras) {
         Intent i = (uri != null ? new Intent(action, uri) : new Intent(action));
-        
+
         if (type != null && uri != null) {
             i.setDataAndType(uri, type); //Fix the crash problem with android 2.3.6
         } else {
@@ -183,18 +179,19 @@ public class WebIntent extends CordovaPlugin {
                 i.setType(type);
             }
         }
-        
+
         for (String key : extras.keySet()) {
             String value = extras.get(key);
-            // If type is text html, the extra text must sent as HTML
+            // If type is text/html, the extra text must be sent as HTML.
             if (key.equals(Intent.EXTRA_TEXT) && type.equals("text/html")) {
                 i.putExtra(key, Html.fromHtml(value));
             } else if (key.equals(Intent.EXTRA_STREAM)) {
-                // allowes sharing of images as attachments.
-                // value in this case should be a URI of a file
-                i.putExtra(key, Uri.parse(value));
+                // Allows sharing of images as attachments.
+                // `value` in this case should be the URI of a file.
+                final CordovaResourceApi resourceApi = webView.getResourceApi();
+                i.putExtra(key, resourceApi.remapUri(Uri.parse(value)));
             } else if (key.equals(Intent.EXTRA_EMAIL)) {
-                // allows to add the email address of the receiver
+                // Allows adding the email address of the receiver.
                 i.putExtra(Intent.EXTRA_EMAIL, new String[] { value });
             } else {
                 i.putExtra(key, value);
@@ -212,5 +209,19 @@ public class WebIntent extends CordovaPlugin {
         }
 
         ((CordovaActivity)this.cordova.getActivity()).sendBroadcast(intent);
+    }
+
+    // Receiver that listens for com.android.vending.INSTALL_REFERRER, an intent sent by the
+    // Play Store on installation when the referrer parameter of the install URL is populated:
+    // https://play.google.com/store/apps/details?id=|APP_ID|&referrer=|REFERRER|
+    public static class ReferralReceiver extends BroadcastReceiver {
+        private static final String LOG_TAG = "ReferralReceiver";
+
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            // Store the install referrer so we can return it when getUri is called.
+            installReferrer = intent.getStringExtra("referrer");
+            Log.i(LOG_TAG, String.format("Install referrer: %s", installReferrer));
+        }
     }
 }

--- a/src/android/WebIntent.java
+++ b/src/android/WebIntent.java
@@ -38,18 +38,16 @@ public class WebIntent extends CordovaPlugin {
     private CallbackContext onNewIntentCallbackContext = null;
 
     /**
-     *
      * @return true iff if the action was executed successfully, else false.
      */
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) {
         try {
-            if (action.equals("startActivity")) {
+            if ("startActivity".equals(action)) {
                 if (args.length() != 1) {
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                     return false;
                 }
-
                 // Parse the arguments
                 final CordovaResourceApi resourceApi = webView.getResourceApi();
                 JSONObject obj = args.getJSONObject(0);
@@ -71,8 +69,7 @@ public class WebIntent extends CordovaPlugin {
                 startActivity(obj.getString("action"), uri, type, extrasMap);
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
                 return true;
-
-            } else if (action.equals("hasExtra")) {
+            } else if ("hasExtra".equals(action)) {
                 if (args.length() != 1) {
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                     return false;
@@ -81,8 +78,7 @@ public class WebIntent extends CordovaPlugin {
                 String extraName = args.getString(0);
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, i.hasExtra(extraName)));
                 return true;
-
-            } else if (action.equals("getExtra")) {
+            } else if ("getExtra".equals(action)) {
                 if (args.length() != 1) {
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                     return false;
@@ -96,12 +92,11 @@ public class WebIntent extends CordovaPlugin {
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR));
                     return false;
                 }
-            } else if (action.equals("getUri")) {
+            } else if ("getUri".equals(action)) {
                 if (args.length() != 0) {
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                     return false;
                 }
-
                 Intent i = ((CordovaActivity)this.cordova.getActivity()).getIntent();
                 String uri = i.getDataString();
                 if (uri == null && installReferrer != null) {
@@ -110,7 +105,7 @@ public class WebIntent extends CordovaPlugin {
                 }
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, uri));
                 return true;
-            } else if (action.equals("onNewIntent")) {
+            } else if ("onNewIntent".equals(action)) {
                 // Save reference to the callback; will be called on "new intent" events.
                 this.onNewIntentCallbackContext = callbackContext;
 
@@ -123,7 +118,7 @@ public class WebIntent extends CordovaPlugin {
                 result.setKeepCallback(true); // Reuse the callback on intent events.
                 callbackContext.sendPluginResult(result);
                 return true;
-            } else if (action.equals("sendBroadcast")) {
+            } else if ("sendBroadcast".equals(action)) {
                 if (args.length() != 1) {
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                     return false;
@@ -152,8 +147,8 @@ public class WebIntent extends CordovaPlugin {
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
             return false;
         } catch (JSONException e) {
-            e.printStackTrace();
             final String errorMessage = e.getMessage();
+            Log.e(LOG_TAG, errorMessage);
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.JSON_EXCEPTION, errorMessage));
             return false;
         }
@@ -170,7 +165,7 @@ public class WebIntent extends CordovaPlugin {
     }
 
     void startActivity(String action, Uri uri, String type, Map<String, String> extras) {
-        Intent i = (uri != null ? new Intent(action, uri) : new Intent(action));
+        Intent i = uri != null ? new Intent(action, uri) : new Intent(action);
 
         if (type != null && uri != null) {
             i.setDataAndType(uri, type); //Fix the crash problem with android 2.3.6
@@ -180,10 +175,11 @@ public class WebIntent extends CordovaPlugin {
             }
         }
 
-        for (String key : extras.keySet()) {
-            String value = extras.get(key);
+        for (Map.Entry<String, String> entry : extras.entrySet()) {
+            final String key = entry.getKey();
+            final String value = entry.getValue();
             // If type is text/html, the extra text must be sent as HTML.
-            if (key.equals(Intent.EXTRA_TEXT) && type.equals("text/html")) {
+            if (key.equals(Intent.EXTRA_TEXT) && "text/html".equals(type)) {
                 i.putExtra(key, Html.fromHtml(value));
             } else if (key.equals(Intent.EXTRA_STREAM)) {
                 // Allows sharing of images as attachments.
@@ -203,11 +199,9 @@ public class WebIntent extends CordovaPlugin {
     void sendBroadcast(String action, Map<String, String> extras) {
         Intent intent = new Intent();
         intent.setAction(action);
-        for (String key : extras.keySet()) {
-            String value = extras.get(key);
-            intent.putExtra(key, value);
+        for (Map.Entry<String, String> entry : extras.entrySet()) {
+            intent.putExtra(entry.getKey(), entry.getValue());
         }
-
         ((CordovaActivity)this.cordova.getActivity()).sendBroadcast(intent);
     }
 

--- a/www/webintent.js
+++ b/www/webintent.js
@@ -15,6 +15,7 @@
     WebIntent.prototype.EXTRA_STREAM = "android.intent.extra.STREAM";
     WebIntent.prototype.EXTRA_EMAIL = "android.intent.extra.EMAIL";
     WebIntent.prototype.ACTION_CALL = "android.intent.action.CALL";
+    WebIntent.prototype.ACTION_SENDTO = "android.intent.action.SENDTO";
 
     WebIntent.prototype.startActivity = function(params, success, fail) {
         return cordova.exec(function(args) {


### PR DESCRIPTION
Primarily this adds support for the [`INSTALL_REFERRER`](https://developers.google.com/analytics/devguides/collection/android/v4/campaigns#google-play-implement) intent, which we (ab)use to encode a proxy server: the administrator of a proxy server can generate an "Install from the Google Play store" link that they can share with a friend, such that when the friend installs uProxy from the Play Store and then runs it for the first time, they start out with the proxy server already added.

This patch also includes some minor code improvements.

Thanks for taking a look!